### PR TITLE
Add ping intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ irc = miniirc.IRC(ip, port, nick, channels = None, *, ssl = None, ident = None, 
 | `realname`    | The realname to use, defaults to `nick` as well.          |
 | `persist`     | Whether to automatically reconnect.                       |
 | `debug`       | Enables debug mode, prints all IRC messages. This can also be a file-like object (with write mode enabled) if you want debug messages to be written into a file instead of being printed to stdout, or a function (for example `logging.debug`). |
-| `ns_identity` | The NickServ account to use (`<user> <password>`).        |
+| `ns_identity` | The NickServ account to use (`<user> <password>`). This can be a tuple or list since miniirc v1.2.0, however for backwards compatibility it should probably be a string. |
 | `auto_connect`| Runs `.connect()` straight away.                          |
 | `ircv3_caps`  | A set() of IRCv3 capabilities to request. SASL is auto-added if `ns_identity` is specified. |
 | `connect_modes` | A mode string (for example `'+B'`) of UMODEs to set when connected. |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To install miniirc, simply run `pip3 install miniirc` as root.
 ## Parameters
 
 ~~~py
-irc = miniirc.IRC(ip, port, nick, channels = None, *, ssl = None, ident = None, realname = None, persist = True, debug = False, ns_identity = None, auto_connect = True, ircv3_caps = set(), quit_message  = 'I grew sick and died.', verify_ssl = True)
+irc = miniirc.IRC(ip, port, nick, channels = None, *, ssl = None, ident = None, realname = None, persist = True, debug = False, ns_identity = None, auto_connect = True, ircv3_caps = set(), quit_message  = 'I grew sick and died.', ping_timeout = 60, verify_ssl = True)
 ~~~
 
 | Parameter     | Description                                                |
@@ -32,6 +32,7 @@ irc = miniirc.IRC(ip, port, nick, channels = None, *, ssl = None, ident = None, 
 | `ircv3_caps`  | A set() of IRCv3 capabilities to request. SASL is auto-added if `ns_identity` is specified. |
 | `connect_modes` | A mode string (for example `'+B'`) of UMODEs to set when connected. |
 | `quit_message`| Sets the default quit message. This can be modified per-quit with `irc.disconnect()`. |
+| `ping_interval` | If no packets are sent or received for this amount of seconds, miniirc will send a `PING`, and if no reply is sent, after the same timeout, miniirc will attempt to reconnect. Set to `None` to disable. |
 | `verify_ssl`  | Verifies TLS/SSL certificates. Disabling this is not recommended. If you have trouble with certificate verification, try running `pip3 install certifi` first. |
 
 ## Functions

--- a/miniirc.py
+++ b/miniirc.py
@@ -158,7 +158,6 @@ class IRC:
     msglen          = 512
     _main_lock      = None
     _sasl           = False
-    _pinged         = False
     _unhandled_caps = None
 
     # Debug print()
@@ -243,6 +242,7 @@ class IRC:
         self.quote('NICK', self.nick, force = True)
         atexit.register(self.disconnect)
         self.debug('Starting main loop...')
+        self._pinged = False
         self.main()
 
     # An easier way to disconnect

--- a/miniirc.py
+++ b/miniirc.py
@@ -327,11 +327,17 @@ class IRC:
                 except Exception as e:
                     self.debug('Lost connection! ', repr(e))
                     self.disconnect(auto_reconnect = True)
-                    if self.persist:
+                    while self.persist:
                         sleep(5)
                         self.debug('Reconnecting...')
                         self._main_lock = None
-                        self.connect()
+                        try:
+                            self.connect()
+                        except:
+                            self.debug('Failed to reconnect!')
+                            self.connected = None
+                        else:
+                            return
                     return
             raw = raw.split(b'\n')
             for line in raw:

--- a/miniirc.py
+++ b/miniirc.py
@@ -9,8 +9,8 @@ import atexit, threading, socket, ssl, sys
 from time import sleep
 
 # The version string and tuple
-ver     = (1,1,4)
-version = 'miniirc IRC framework v1.1.4'
+ver     = (1,2,0)
+version = 'miniirc IRC framework v1.2.0'
 
 # __all__ and _default_caps
 __all__ = ['Handler', 'IRC']
@@ -363,19 +363,11 @@ class IRC:
 
     # Initialize the class
     def __init__(self, ip, port, nick, channels = None, *,
-      ssl           = None, # None: Auto
-      ident         = None,
-      realname      = None,
-      persist       = True,
-      debug         = False,
-      ns_identity   = None,
-      auto_connect  = True,
-      ircv3_caps    = set(),
-      connect_modes = None,
-      quit_message  = 'I grew sick and died.',
-      ping_interval = 60,
-      verify_ssl    = True
-      ):
+            ssl = None, ident = None, realname = None, persist = True,
+            debug = False, ns_identity = None, auto_connect = True,
+            ircv3_caps = set(), connect_modes = None,
+            quit_message = 'I grew sick and died.', ping_interval = 60,
+            verify_ssl = True):
         # Set basic variables
         self.ip             = ip
         self.port           = int(port)
@@ -385,7 +377,6 @@ class IRC:
         self.realname       = realname or nick
         self.ssl            = ssl
         self.persist        = persist
-        self.ns_identity    = ns_identity
         self.ircv3_caps     = set(ircv3_caps or ()) | _default_caps
         self.active_caps    = set()
         self.isupport       = {}
@@ -393,6 +384,12 @@ class IRC:
         self.quit_message   = quit_message
         self.ping_interval  = ping_interval
         self.verify_ssl     = verify_ssl
+
+        # Set the NickServ identity
+        if not ns_identity or isinstance(ns_identity, str):
+            self.ns_identity = ns_identity
+        else:
+            self.ns_identity = ' '.join(ns_identity)
 
         # Set the debug file
         if not debug:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md', 'r') as f:
 
 setup(
     name        = 'miniirc',
-    version     = '1.1.4',
+    version     = '1.2.0',
     py_modules  = ['miniirc'],
     author      = 'luk3yx',
     description = 'A lightweight IRC framework.',


### PR DESCRIPTION
Allows miniirc to send `PING`s to the remote server so timeouts can be handled nicely.

This should fix/close #11.